### PR TITLE
add line number to parser error messages

### DIFF
--- a/src/parse/lex.rkt
+++ b/src/parse/lex.rkt
@@ -4,8 +4,7 @@
          end-lex
          get-next-symbol
          unget-next-symbol
-         line-number
-         col-number)
+         line-number)
 
 ;;===============================================================
 ;; The Lexical Analyzer
@@ -19,7 +18,6 @@
 (define last-symbol-saved #f)   ; is there a symbol buffered?
 (define saved-symbol #f)        ; the symbol buffer
 (define line-number 0)
-(define col-number 0)
 
 ; gets the next symbol to be processed
 ;
@@ -55,7 +53,10 @@
         (begin
           (set! saved-last-char #f)
           last-read-char)
-        (read-char port))))
+        (let ([char  (read-char port)])
+          (when (eqv? #\newline char)
+            (set! line-number (+ 1 line-number)))
+          char))))
 
 ; unread the last character from the file so it can be read again
 
@@ -154,11 +155,6 @@
 (define lex
   (lambda ()
     (let ((nextchar (readchar file-port)))
-      (if (eq? nextchar #\newline)
-          (begin
-            (set! col-number 0)
-            (set! line-number (+ 1 line-number)))
-          (set! col-number (+ 1 col-number)))
       (cond ((eof-object? nextchar) (return-eof-lex))
             ((char-whitespace? nextchar) (lex))
             ((char-alphabetic? nextchar) (return-id-lex (string->symbol (id-lex file-port (make-string 1 nextchar)))))

--- a/test/parse/parser-tests.rkt
+++ b/test/parse/parser-tests.rkt
@@ -1,0 +1,83 @@
+#lang racket/base
+(require rackunit
+         (prefix-in simple- "../../src/parse/simpleParser.rkt")
+         (prefix-in function- "../../src/parse/functionParser.rkt")
+         (prefix-in class- "../../src/parse/classParser.rkt"))
+
+; ; v1
+
+(test-not-exn
+ "v1, comprehensive"
+ (λ () (simple-parser-str "
+var x = 0;
+while(x < 12) {
+  try{
+    x = x + 10;
+    break;
+  }catch(e) {
+   if (true || false) return 0;
+  } finally {
+     x = x+1;
+  }
+}
+return x;
+")))
+
+; ; v2
+
+(test-not-exn
+ "v2, comprehensive"
+ (λ () (function-parser-str "
+function divide(x, y) {
+  if (y == 0)
+    throw 1000000;
+  return x / y;
+}
+
+ function main() {
+  var x = 0;
+  var j = 1;
+
+  try {
+    while (j >= 0) {
+    var i = 10;
+    while (i >= 0) {
+      try {
+        x = x + divide(10*i, i);
+      }
+      catch(e) {
+        x = x + divide(e, j);
+      }
+      i = i - 1;
+    }
+    j = j - 1;
+   }
+  }
+  catch (e2) {
+    x = x * 2;
+  }
+  return x;
+}")))
+
+; ; v3
+
+(test-not-exn
+ "v3, comprehensive"
+ (λ () (class-parser-str "
+class A extends Bclass {
+  static var sfield;
+  var ifield = c;
+  var ifield = 1 + x.y.funcall();
+  A() { super(); }
+  A(a, b) { this(); }
+  function abstr(&a, b);
+  function inst(a, b, &c) {
+    this.x();
+    super.foo(this.y);
+    return super.x;
+  }
+  static function main() {
+    a();
+    throw 3 + 3;
+  }
+}")))


### PR DESCRIPTION
closes #56  
parser error messages will now report the line number on which the error was detected.  
the col-number portion was scrapped because in practice the values turned out to not be very useful - mostly pointing to the end or beginning of a line.