### PR TITLE
some Mbool type errors as user-exns, test cases

### DIFF
--- a/src/user-errors.rkt
+++ b/src/user-errors.rkt
@@ -101,6 +101,17 @@
             "uncaught exception: ~a"
             'exn-val))
 
+(define type:expected-boolean-val 'expected-boolean-val)
+(define expected-boolean-val
+  (exn:ctor type:expected-boolean-val
+            "expected a boolean, got: `~a`"
+            'val))
+
+(define type:expected-boolean-expr 'expected-boolean-expr)
+(define expected-boolean-expr
+  (exn:ctor type:expected-boolean-expr
+            "expected a boolean expression, got: `~a`"
+            'expr))
 
 
 (define type:non-var-in-ref-param 'non-variable-in-reference-param)

--- a/test/op-error-tests.rkt
+++ b/test/op-error-tests.rkt
@@ -1,0 +1,80 @@
+#lang racket/base
+
+(require "error-test-shared.rkt"
+         "../src/interpreter-extension.rkt"
+         "../src/user-errors.rkt"
+         rackunit)
+
+
+(define (i program)
+  (interpret-v1-str program
+                    #:return (λ (v s) (fail-check "expected an error"))
+                    #:user-exn test-user-exn
+                    #:throw (λ (e s)
+                              (test-user-exn (ue:uncaught-exception e) s))))
+
+
+; ; SHORT-CIRCUIT ||, &&
+
+(test-case
+ "int literal in ||"
+ (check-exn-result (i "return 1 || false;")
+                   ue:type:expected-boolean-val
+                   '(return))
+ (check-exn-result (i "return false || 1;")
+                   ue:type:expected-boolean-val
+                   '(return)))
+ 
+(test-case
+ "int literal in &&"
+ (check-exn-result (i "return 1 && true;")
+                   ue:type:expected-boolean-val
+                   '(return))
+ (check-exn-result (i "return true && 1;")
+                   ue:type:expected-boolean-val
+                   '(return)))
+ 
+(test-case
+ "int expression in ||"
+ (check-exn-result (i "return (1 + 2) || false;")
+                   ue:type:expected-boolean-expr
+                   '(return))
+ (check-exn-result (i "return false || (2 + 1);")
+                   ue:type:expected-boolean-expr
+                   '(return)))
+ 
+(test-case
+ "int expression in &&"
+ (check-exn-result (i "return (1 + 2) && false;")
+                   ue:type:expected-boolean-expr
+                   '(return))
+ (check-exn-result (i "return true && (2 + 1);")
+                   ue:type:expected-boolean-expr
+                   '(return)))
+ 
+(test-case
+ "LHS type error in || detected before RHS"
+ (check-exn-result (i "return 1 || (1 + 1);")
+                   ue:type:expected-boolean-val
+                   '(return))
+ (check-exn-result (i "return (1 + 1) || 1;")
+                   ue:type:expected-boolean-expr
+                   '(return)))
+
+(test-case
+ "LHS type error in && detected before RHS"
+ (check-exn-result (i "return 1 || (1 + 1);")
+                   ue:type:expected-boolean-val
+                   '(return))
+ (check-exn-result (i "return (1 + 1) || 1;")
+                   ue:type:expected-boolean-expr
+                   '(return)))
+
+(test-case
+ "chained || and &&"
+ (check-exn-result (i "return 1 || 1/0 || 1/0;")
+                   ue:type:expected-boolean-val
+                   '(return))
+ (check-exn-result (i "return 1 && 1/0 && 1/0;")
+                   ue:type:expected-boolean-val
+                   '(return)))

--- a/test/v1-error-tests.rkt
+++ b/test/v1-error-tests.rkt
@@ -275,3 +275,22 @@ finally {
                    ue:type:did-not-return
                    '()))
 
+; ; non-bool in if/while condition
+
+(test-case
+ "int in if cond"
+ (check-exn-result (i "if (1) return 0;")
+                   ue:type:expected-boolean-val
+                   '(if))
+ (check-exn-result (i "if (1 + 1) return 0;")
+                   ue:type:expected-boolean-expr
+                   '(if)))
+
+(test-case
+ "int in while cond"
+ (check-exn-result (i "while (1) return 0;")
+                   ue:type:expected-boolean-val
+                   '(while))
+ (check-exn-result (i "while (1 + 1) return 0;")
+                   ue:type:expected-boolean-expr
+                   '(while)))

--- a/test/v2-error-tests.rkt
+++ b/test/v2-error-tests.rkt
@@ -393,3 +393,43 @@ function main() { functor(); }")])
    (check-exn-result result
                      ue:type:duplicate-parameter
                      '(function "functor()" funcall "main()"))))
+
+
+; ; Boolean type errors
+(test-case
+ "Int returning function in || / &&"
+ (check-exn-result (i "function foo() { return 1; }  function main() { return foo() || true; }")
+                   ue:type:expected-boolean-val
+                   '(return "main()"))
+ (check-exn-result (i "function foo() { return 1; }  function main() { return  true && foo(); }")
+                   ue:type:expected-boolean-val
+                   '(return "main()")))
+
+(test-case
+ "Int returning function in if/while cond"
+ (check-exn-result (i "function foo() { return 1; }  function main() { if (foo()) return 0; }")
+                   ue:type:expected-boolean-val
+                   '(if "main()"))
+ (check-exn-result (i "function foo() { return 1; }  function main() { while (foo()) return 0; }")
+                   ue:type:expected-boolean-val
+                   '(while "main()")))
+
+(test-case
+ "Int returning function in || / && in fun arg"
+ (check-exn-result (i "function foo(b) { return b; }  function main() { return foo(1 || 2); }")
+                   ue:type:expected-boolean-val
+                   '(return "main()"))
+ (check-exn-result (i "function foo(b) { return b; }  function main() { return foo((1 + 1) && 2); }")
+                   ue:type:expected-boolean-expr
+                   '(return "main()")))
+
+(test-case
+ "int val/ref param used in if/while cond"
+ (check-exn-result (i "function foo(b) { if (b) return 0; }  function main() { return foo(1); }")
+                   ue:type:expected-boolean-val
+                   '(if "foo(b)" return "main()"))
+ (check-exn-result (i "function foo(&b) { while (b) return 0; }  function main() { var a = 1; return foo(a); }")
+                   ue:type:expected-boolean-val
+                   '(while "foo(&b)" return "main()")))
+ 
+ 


### PR DESCRIPTION
* added two new exn types
* test cases for if/while cond, ||, &&, ints, instances, val/ref params
* does not include ! or other ops, because the operands are evaluated in
  a shared function which uses Mvalue. solution should perhaps be
  delayed until types are implemented

mostly closes #48 