### PR TITLE
add support for line and block comments

### DIFF
--- a/test/parse/parser-error-tests.rkt
+++ b/test/parse/parser-error-tests.rkt
@@ -105,3 +105,36 @@
   "abstract function in block"
   "{ function a(); }"))
 
+(test-case
+ "block comment inside identifiers"
+ (test-parser-exn
+  "block comment in var keyword"
+  "va/* comment */r x = 1; return 1;")
+ (test-parser-exn
+  "block comment in var name"
+  "var lon/* comment */gName = 2; return longName;"))
+
+(test-case
+ "unclosed block comments"
+ (test-parser-exn
+  "unclosed block comment in beginning of prog"
+  "/* this is a block comment
+var x;
+return x;")
+ (test-parser-exn
+  "unclosed block comment in end of prog"
+  "var x = 1;
+return x;
+/* this is a block comment")
+ (test-parser-exn
+  "unclosed block comment in middle of prog"
+  "var x;
+/* this is a block comment
+return x;")
+ (test-parser-exn
+  "start and end delimiter can't share *"
+  "var a; /*/")
+ (test-parser-exn
+  "block comments don't nest"
+  "var a; /* /* */ */"))
+

--- a/test/parse/parser-tests.rkt
+++ b/test/parse/parser-tests.rkt
@@ -1,5 +1,6 @@
 #lang racket/base
 (require rackunit
+         racket/string
          "../../src/parse/parser.rkt")
 
 ; ; v1
@@ -160,3 +161,58 @@ class A { }")
    (if false (begin))
    (class A () ())))
 
+; ; Comments
+; replacing the comment with white space should produce identical parse-trees
+(define-check (test-cmnt-parse msg str)
+  (test-equal?
+   msg
+   (parse-str str)
+   (parse-str (string-replace str #rx"//.*?\n|/\\*.*?\\*/" " "))))
+
+(test-cmnt-parse
+ "line comment at end of var decl line, spaces"
+ "var x; // important variable")
+
+(test-cmnt-parse
+ "line comment at end of var decl line, no spaces"
+ "var x;//important variable")
+
+(test-cmnt-parse
+ "block comment between tokens, chars adjacent to delimiters"
+ "var /**/ x;")
+
+(test-cmnt-parse
+ "block comment between tokens, with spaces"
+ "var /*abcd*/ x;")
+
+(test-cmnt-parse
+ "block comment between tokens, without spaces"
+ "var/**/x;")
+
+(test-cmnt-parse
+ "block comment between tokens, 3 stars"
+ "var/***/x;")
+
+(test-cmnt-parse
+ "block comment between tokens, 4 stars"
+ "var/****/x;")
+
+(test-cmnt-parse
+ "block comment between tokens, multiple start delimiters"
+ "var/*/* /* */x;")
+
+(test-cmnt-parse
+ "block comment between token and semicolon, without spaces"
+ "var x/**/;")
+
+(test-cmnt-parse
+ "line comment only spans one line"
+ "var x; // comment
+var y;
+var z;")
+
+(test-cmnt-parse
+ "line comment inside block comment doesn't ignore end */"
+ "var x; /* block start
+ // line-comment block-end */
+var y;")


### PR DESCRIPTION
* move parse-error from parser to lex, rename to parsing-error
* add test cases for comments
* line comments with //
* block comments with /**/

closes #64 
