### PR TITLE
Tweak ci action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,39 @@
+# produce a test coverage artifact
+name: coverage
+
+on:
+  workflow_call:
+  
+jobs:
+  setup-racket:
+  runs-on: ubuntu-latest
+  steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache Racket dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/racket
+            ~/.local/share/racket
+          key: ${{ runner.os }}-racket-8.5
+
+      - name: Install Racket
+        uses: Bogdanp/setup-racket@v1.8.1
+        with:
+          architecture: 'x64'
+          distribution: 'full'
+          variant: 'CS'
+          version: '8.5'
+
+      - name: Install Dependencies
+        run: raco pkg install --auto --skip-installed cover
+        
+      - run: raco cover -Q src test
+      
+      - name: Archive code coverage reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: code-coverage-report
+          path: coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,8 +6,8 @@ on:
   
 jobs:
   setup-racket:
-  runs-on: ubuntu-latest
-  steps:
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Cache Racket dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/racket
+            ~/.local/share/racket
+          key: ${{ runner.os }}-racket-8.2
+
       - name: Install Racket
         uses: Bogdanp/setup-racket@v1.6.1
         with:
@@ -25,14 +33,15 @@ jobs:
           distribution: 'full'
           variant: 'CS'
           version: '8.2'
-          
+
       - name: Install Dependencies
-        run: raco pkg install --auto cover
+        run: raco pkg install --auto --skip-installed cover
         
       - name: Run Tests
         run: raco test -e --timeout 120 -q --table --jobs 10 src test
         
-      - run: raco cover src test
+      - run: raco cover -Q src test
+      
       - name: Archive code coverage reports
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,14 +18,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Cache Racket dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cache/racket
-            ~/.local/share/racket
-          key: ${{ runner.os }}-racket-8.5
-
       - name: Install Racket
         uses: Bogdanp/setup-racket@v1.8.1
         with:
@@ -33,18 +25,7 @@ jobs:
           distribution: 'full'
           variant: 'CS'
           version: '8.5'
-
-      - name: Install Dependencies
-        run: raco pkg install --auto --skip-installed cover
-        
+          
       - name: Run Tests
         run: raco test -e --timeout 120 -q --table --jobs 6 src test
-        
-      - run: raco cover -Q src test
-      
-      - name: Archive code coverage reports
-        uses: actions/upload-artifact@v3
-        with:
-          name: code-coverage-report
-          path: coverage
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
           key: ${{ runner.os }}-racket-8.2
 
       - name: Install Racket
-        uses: Bogdanp/setup-racket@v1.6.1
+        uses: Bogdanp/setup-racket@v1.8.1
         with:
           architecture: 'x64'
           distribution: 'full'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
           path: |
             ~/.cache/racket
             ~/.local/share/racket
-          key: ${{ runner.os }}-racket-8.2
+          key: ${{ runner.os }}-racket-8.5
 
       - name: Install Racket
         uses: Bogdanp/setup-racket@v1.8.1
@@ -32,13 +32,13 @@ jobs:
           architecture: 'x64'
           distribution: 'full'
           variant: 'CS'
-          version: '8.2'
+          version: '8.5'
 
       - name: Install Dependencies
         run: raco pkg install --auto --skip-installed cover
         
       - name: Run Tests
-        run: raco test -e --timeout 120 -q --table --jobs 10 src test
+        run: raco test -e --timeout 120 -q --table --jobs 6 src test
         
       - run: raco cover -Q src test
       


### PR DESCRIPTION
* cache package dependencies
* bump `racket` version
* bump `setup-racket` version
* add `quiet` flag to `raco cover`
* reduce number of jobs in `raco test` from 10 to 6