### PR TITLE
add type-mismatch and divide-by-zero operator errors

### DIFF
--- a/src/interpret/interpreter.rkt
+++ b/src/interpret/interpreter.rkt
@@ -1349,9 +1349,21 @@
 (define apply-op
   (lambda (op-symbol vals state context conts)
     (let ([sig-list  (operator-type-signature-list op-symbol)])
-      (if (member (map type-of vals) sig-list)
+      (if (memf (λ (sig) (vals-match-sig? vals sig state context))
+                sig-list)
           ((return conts) (apply (op-symbol->proc op-symbol) vals) state)
           ((user-exn conts) (ue:type-mismatch sig-list vals) state)))))
+
+(define vals-match-sig?
+  (lambda (vals sig state context)
+    (cond
+      ; should be same length
+      [(and (null? vals)
+            (null? sig))   #T]
+      [(or (null? vals)
+           (null? sig))    #F]
+      [else                (and (compatible? (car vals) (car sig) state context)
+                                (vals-match-sig? (cdr vals) (cdr sig) state context))])))
 
 ;; takes a list of exprs and maps them to values,
 ;; propagating the state changes (so that they evaluate correctly)

--- a/src/interpret/interpreter.rkt
+++ b/src/interpret/interpreter.rkt
@@ -1340,10 +1340,12 @@
 (define apply-op
   (lambda (op-symbol vals state context conts)
     (let ([sig-list  (operator-type-signature-list op-symbol)])
-      (if (memf (λ (sig) (vals-match-sig? vals sig state context))
-                sig-list)
-          ((return conts) (apply (op-symbol->proc op-symbol) vals) state)
-          ((user-exn conts) (ue:type-mismatch op-symbol sig-list vals) state)))))
+      (cond
+        [(and (eq? op-symbol '/)
+              (eq? (second vals) 0)) ((user-exn conts) (ue:divide-by-zero) state)]
+        [(memf (λ (sig) (vals-match-sig? vals sig state context))
+               sig-list)             ((return conts) (apply (op-symbol->proc op-symbol) vals) state)]
+        [else                        ((user-exn conts) (ue:type-mismatch op-symbol sig-list vals) state)]))))
 
 (define vals-match-sig?
   (lambda (vals sig state context)

--- a/src/interpret/interpreter.rkt
+++ b/src/interpret/interpreter.rkt
@@ -1526,7 +1526,7 @@
     (map:contains? (action nested-expr) boolean-op-table)))
 
 (define is-&&? (checker-of '&&))
-(define is-||? (checker-of '||))
+(define is-||? (checker-of '\|\|))
 
 ;; Takes a nested expression and returns whether it contains a recognized operation
 (define has-op?
@@ -1540,7 +1540,7 @@
 (define boolean-op-table
   (map:of
    '&& error ; short-circuit ops must be handled as a special case
-   '|| error
+   '\|\| error
    '!  not
    '== eq?
    '!= (lambda (a b) (not (eq? a b)))

--- a/src/interpret/io-format.rkt
+++ b/src/interpret/io-format.rkt
@@ -1,0 +1,19 @@
+#lang racket/base
+(provide format-val-for-output)
+(require "state/instance.rkt")
+
+;;;;
+;; this module contains functions for the formatting of values output by the intepreter
+
+;; takes a value and modifies it for output
+; int as number
+; boolean as symbol (matching source code)
+; instance as JSON string (WIP)
+(define format-val-for-output
+  (lambda (value)
+    (cond
+      [(eq? #t value)         'true]
+      [(eq? #f value)         'false]
+      [(number? value)        value]
+      [(is-instance? value)   value]
+      [else                   (error "returned an unsupported type: " value)])))

--- a/src/interpret/state/state.rkt
+++ b/src/interpret/state/state.rkt
@@ -42,7 +42,7 @@
 
                                   declare-class
                                   has-class?
-                                  get-class
+                                  subclass?
                                   current-type-parent-name
                                   current-type-has-parent?
                                   get-parent-name
@@ -530,6 +530,13 @@
     (if (has-parent? class-name context state)
         (+ 1 (get-class-height (get-parent-name class-name context state) context state))
         1)))
+
+; class1 instanceof class2
+(define subclass?
+  (lambda (class1 class2 context state)
+    (or (eq? class1 class2)
+        (and (has-parent? class1 context state)
+             (get-parent-name class1 context state)))))
 
 ;; declares an empty class
 (define declare-class

--- a/src/interpret/type.rkt
+++ b/src/interpret/type.rkt
@@ -1,19 +1,58 @@
 #lang racket/base
-(require "state/instance.rkt")
-(provide type-of)
+(require "state/instance.rkt"
+         "state/state.rkt")
+(provide type-of
+         compatible?
+         (prefix-out type: (combine-out any bool int)))
 
-;;;; functions related to the type system
+;;;; constants and functions related to the type system
+
+(define any 'any)
+(define bool 'bool)
+(define int 'int)
 
 (define (type-of val)
   (cond
-    [(boolean? val)      'boolean]
-    [(number? val)       'int]
+    [(boolean? val)      bool]
+    [(number? val)       int]
     [(is-instance? val)  (instance:class val)]))
 
 (module+ test
   (require rackunit)
-  (check-equal? (type-of 4)  'int)
-  (check-equal? (type-of #T) 'boolean)
-  (check-equal? (type-of #F) 'boolean)
-  (check-equal? (type-of '((fields) (class . A))) 'A)
-  (check-equal? (type-of '((fields (k . v) (a . b)) (class . Foo))) 'Foo))
+  (define sample-object-1 '((fields) (class . A)))
+  (define sample-object-2 '((fields ((k . v)) ((a . 5))) (class . Foo)))
+  (check-equal? (type-of 4)  int)
+  (check-equal? (type-of #T) bool)
+  (check-equal? (type-of #F) bool)
+  (check-equal? (type-of sample-object-1) 'A)
+  (check-equal? (type-of sample-object-2) 'Foo))
+
+; is v accepted where a value of type t is required?
+(define (compatible? v t context state)
+  (not (not (case t
+              [(any)       #T]
+              [(bool)      (boolean? v)]
+              [(int)       (number? v)]
+              ; else object
+              [else        (and (is-instance? v)
+                                (state:subclass? (type-of v) t context state))]))))
+
+(module+ test
+  (define-check (check-all-true pred vs)
+    (when (not (null? vs))
+      (check-true (pred (car vs)))
+      (check-all-true pred (cdr vs))))
+  (check-true (compatible? 5 int #F new-state))
+  (check-true (compatible? 0 int #F new-state))
+  (check-true (compatible? -5 int #F new-state))
+  (check-true (compatible? #T bool #F new-state))
+  (check-true (compatible? #F bool #F new-state))
+
+  (check-all-true (λ (v) (not (compatible? v bool #F new-state)))
+                  '(5 0 -5 sample-object-1 sample-object-2))
+  (check-all-true (λ (v) (not (compatible? v int #F new-state)))
+                  '(#T #F sample-object-1 sample-object-2))
+  (check-all-true (λ (v) (not (compatible? v 'A #F new-state)))
+                  '(5 0 -5 #T #F sample-object-2))
+  (check-all-true (λ (v) (compatible? v any #F new-state))
+                  '(5 0 -5 #T #F sample-object-1 sample-object-2)))

--- a/src/interpret/type.rkt
+++ b/src/interpret/type.rkt
@@ -71,4 +71,4 @@
       [(!)                   bool]
       [(== !=)               any-any]
       [(< <= > >= + / * %)   int-int]
-      [(-)                   (append int-int int)])))
+      [(-)                   (append int int-int)])))

--- a/src/interpret/type.rkt
+++ b/src/interpret/type.rkt
@@ -1,0 +1,19 @@
+#lang racket/base
+(require "state/instance.rkt")
+(provide type-of)
+
+;;;; functions related to the type system
+
+(define (type-of val)
+  (cond
+    [(boolean? val)      'boolean]
+    [(number? val)       'int]
+    [(is-instance? val)  (instance:class val)]))
+
+(module+ test
+  (require rackunit)
+  (check-equal? (type-of 4)  'int)
+  (check-equal? (type-of #T) 'boolean)
+  (check-equal? (type-of #F) 'boolean)
+  (check-equal? (type-of '((fields) (class . A))) 'A)
+  (check-equal? (type-of '((fields (k . v) (a . b)) (class . Foo))) 'Foo))

--- a/src/interpret/type.rkt
+++ b/src/interpret/type.rkt
@@ -29,7 +29,7 @@
   (check-equal? (type-of sample-object-2) 'Foo))
 
 ; is v accepted where a value of type t is required?
-(define (compatible? v t context state)
+(define (compatible? v t state context)
   (not (not (case t
               [(any)       #T]
               [(bool)      (boolean? v)]

--- a/src/interpret/type.rkt
+++ b/src/interpret/type.rkt
@@ -3,6 +3,7 @@
          "state/state.rkt")
 (provide type-of
          compatible?
+         operator-type-signature-list
          (prefix-out type: (combine-out any bool int)))
 
 ;;;; constants and functions related to the type system
@@ -56,3 +57,18 @@
                   '(5 0 -5 #T #F sample-object-2))
   (check-all-true (λ (v) (compatible? v any #F new-state))
                   '(5 0 -5 #T #F sample-object-1 sample-object-2)))
+
+
+;; each operator has a list of valid signatures. each signature is a list of types
+(define (operator-type-signature-list op-symbol)
+  (let ([any-any    (list (list any any))]
+        [bool-bool  (list (list bool bool))]
+        [int-int    (list (list int int))]
+        [bool       (list (list bool))]
+        [int        (list (list int))])
+    (case op-symbol
+      [(&& ||)               bool-bool]
+      [(!)                   bool]
+      [(== !=)               any-any]
+      [(< <= > >= + / * %)   int-int]
+      [(-)                   (append int-int int)])))

--- a/src/interpret/user-errors.rkt
+++ b/src/interpret/user-errors.rkt
@@ -137,6 +137,11 @@
             "expected a boolean expression, got: `~a`"
             'expr))
 
+(define type:divide-by-zero 'divide-by-zero)
+(define divide-by-zero
+  (exn:ctor type:divide-by-zero
+            "attempted to divide by zero"))
+
 
 
 (define type:non-var-in-ref-param 'non-variable-in-reference-param)

--- a/src/interpret/user-errors.rkt
+++ b/src/interpret/user-errors.rkt
@@ -106,10 +106,11 @@
             "uncaught exception: ~a"
             'exn-val))
 
-(define type:expected-boolean-val 'expected-boolean-val)
-(define expected-boolean-val
-  (exn:ctor type:expected-boolean-val
-            "expected a boolean, got: `~a`"
+(define type:type-mismatch 'type-mismatch)
+(define type-mismatch
+  (exn:ctor type:type-mismatch
+            "expected a value of type `~a`, got: `~a`"
+            'expected-type
             'val))
 
 (define type:expected-boolean-expr 'expected-boolean-expr)

--- a/src/interpret/user-errors.rkt
+++ b/src/interpret/user-errors.rkt
@@ -109,7 +109,7 @@
 (define type:type-mismatch 'type-mismatch)
 (define type-mismatch
   (exn:ctor type:type-mismatch
-            "expected a value of type `~a`, got: `~a`"
+            "expected type(s) `~a`, given value(s): `~a`"
             'expected-type
             'val))
 

--- a/src/parse/parser.rkt
+++ b/src/parse/parser.rkt
@@ -443,7 +443,7 @@
   (lambda (firstoperand)
     (let ((op (get-next-symbol)))
       (if (and (eq? (car op) 'BINARY-OP) (eq? (cdr op) '\|\|))
-          (orterm-parse-helper (list '|| firstoperand (andterm-parse (get-next-symbol))))
+          (orterm-parse-helper (list '\|\| firstoperand (andterm-parse (get-next-symbol))))
           (begin
             (unget-next-symbol)
             firstoperand)))))

--- a/src/src-gen.rkt
+++ b/src/src-gen.rkt
@@ -1,7 +1,10 @@
 #lang racket/base
 (require racket/list
          racket/string)
-(provide AST-path->stack-trace)
+(provide AST-path->stack-trace
+         (rename-out [statement  statement-AST->src-string]
+                     [value      value-AST->src-string]
+                     [stmt-list  stmt-list-AST->src-string]))
 
 ;;;; Takes AST nodes from parser
 ;;;; and produces equivalent source code

--- a/test/interpret/op-error-tests.rkt
+++ b/test/interpret/op-error-tests.rkt
@@ -1,35 +1,42 @@
 #lang racket/base
 
 (require "../test-shared.rkt"
-         "../../src/interpret/interpreter.rkt"
          "../../src/interpret/user-errors.rkt"
+         "../../src/interpret/type.rkt"
          rackunit)
 
 
 (define (i program)
   (i-exn-str program mode:script))
 
+(define-check (check-type-error exn-result expected-type expected-val)
+  (define exn (car exn-result))
+  (check-equal? (ue:exn:type exn) ue:type:type-mismatch)
+  (check-equal? (ue:exn:property 'expected-type exn)
+                expected-type)
+  (check-equal? (ue:exn:property 'val exn)
+                expected-val))
 
 ; ; SHORT-CIRCUIT ||, &&
 
 (test-case
  "int literal in ||"
- (check-exn-result (i "return 1 || false;")
-                   ue:type:expected-boolean-val
-                   '(return))
- (check-exn-result (i "return false || 1;")
-                   ue:type:expected-boolean-val
-                   '(return)))
- 
+ (check-type-error (i "return 1 || false;")
+                   type:bool
+                   1)
+ (check-type-error (i "return false || 1;")
+                   type:bool
+                   1))
+
 (test-case
  "int literal in &&"
- (check-exn-result (i "return 1 && true;")
-                   ue:type:expected-boolean-val
-                   '(return))
- (check-exn-result (i "return true && 1;")
-                   ue:type:expected-boolean-val
-                   '(return)))
- 
+ (check-type-error (i "return 1 && true;")
+                   type:bool
+                   1)
+ (check-type-error (i "return true && 1;")
+                   type:bool
+                   1))
+
 (test-case
  "int expression in ||"
  (check-exn-result (i "return (1 + 2) || false;")
@@ -38,7 +45,7 @@
  (check-exn-result (i "return false || (2 + 1);")
                    ue:type:expected-boolean-expr
                    '(return)))
- 
+
 (test-case
  "int expression in &&"
  (check-exn-result (i "return (1 + 2) && false;")
@@ -47,30 +54,30 @@
  (check-exn-result (i "return true && (2 + 1);")
                    ue:type:expected-boolean-expr
                    '(return)))
- 
+
 (test-case
  "LHS type error in || detected before RHS"
- (check-exn-result (i "return 1 || (1 + 1);")
-                   ue:type:expected-boolean-val
-                   '(return))
+ (check-type-error (i "return 1 || (1 + 1);")
+                   type:bool
+                   1)
  (check-exn-result (i "return (1 + 1) || 1;")
                    ue:type:expected-boolean-expr
                    '(return)))
 
 (test-case
  "LHS type error in && detected before RHS"
- (check-exn-result (i "return 1 || (1 + 1);")
-                   ue:type:expected-boolean-val
-                   '(return))
+ (check-type-error (i "return 1 || (1 + 1);")
+                   type:bool
+                   1)
  (check-exn-result (i "return (1 + 1) || 1;")
                    ue:type:expected-boolean-expr
                    '(return)))
 
 (test-case
  "chained || and &&"
- (check-exn-result (i "return 1 || 1/0 || 1/0;")
-                   ue:type:expected-boolean-val
-                   '(return))
- (check-exn-result (i "return 1 && 1/0 && 1/0;")
-                   ue:type:expected-boolean-val
-                   '(return)))
+ (check-type-error (i "return 1 || 1/0 || 1/0;")
+                   type:bool
+                   1)
+ (check-type-error (i "return 1 && 1/0 && 1/0;")
+                   type:bool
+                   1))

--- a/test/interpret/op-error-tests.rkt
+++ b/test/interpret/op-error-tests.rkt
@@ -9,6 +9,10 @@
 (define (i program)
   (i-exn-str program mode:script))
 
+(define-check (check-bool-expr-exn exn-result expr-string)
+  (check-equal? (ue:exn:type (car exn-result)) ue:type:expected-boolean-expr)
+  (check-equal? (ue:exn:property 'expr (car exn-result)) expr-string))
+
 (define-check (check-type-error exn-result expected-type expected-val)
   (define exn (car exn-result))
   (check-equal? (ue:exn:type exn) ue:type:type-mismatch)
@@ -21,63 +25,35 @@
 
 (test-case
  "int literal in ||"
- (check-type-error (i "return 1 || false;")
-                   type:bool
-                   1)
- (check-type-error (i "return false || 1;")
-                   type:bool
-                   1))
+ (check-bool-expr-exn (i "return 1 || false;") "1")
+ (check-bool-expr-exn (i "return false || 1;") "1"))
 
 (test-case
  "int literal in &&"
- (check-type-error (i "return 1 && true;")
-                   type:bool
-                   1)
- (check-type-error (i "return true && 1;")
-                   type:bool
-                   1))
+ (check-bool-expr-exn (i "return 1 && true;") "1")
+ (check-bool-expr-exn (i "return true && 1;") "1"))
 
 (test-case
  "int expression in ||"
- (check-exn-result (i "return (1 + 2) || false;")
-                   ue:type:expected-boolean-expr
-                   '(return))
- (check-exn-result (i "return false || (2 + 1);")
-                   ue:type:expected-boolean-expr
-                   '(return)))
+ (check-bool-expr-exn (i "return (1 + 2) || false;") "1 + 2")
+ (check-bool-expr-exn (i "return false || (2 + 1);") "2 + 1"))
 
 (test-case
  "int expression in &&"
- (check-exn-result (i "return (1 + 2) && false;")
-                   ue:type:expected-boolean-expr
-                   '(return))
- (check-exn-result (i "return true && (2 + 1);")
-                   ue:type:expected-boolean-expr
-                   '(return)))
+ (check-bool-expr-exn (i "return (1 + 2) && false;") "1 + 2")
+ (check-bool-expr-exn (i "return true && (2 + 1);") "2 + 1"))
 
 (test-case
  "LHS type error in || detected before RHS"
- (check-type-error (i "return 1 || (1 + 1);")
-                   type:bool
-                   1)
- (check-exn-result (i "return (1 + 1) || 1;")
-                   ue:type:expected-boolean-expr
-                   '(return)))
+ (check-bool-expr-exn (i "return 1 || (1 + 1);") "1")
+ (check-bool-expr-exn (i "return (1 + 1) || 1;") "1 + 1"))
 
 (test-case
  "LHS type error in && detected before RHS"
- (check-type-error (i "return 1 || (1 + 1);")
-                   type:bool
-                   1)
- (check-exn-result (i "return (1 + 1) || 1;")
-                   ue:type:expected-boolean-expr
-                   '(return)))
+ (check-bool-expr-exn (i "return 1 || (1 + 1);") "1")
+ (check-bool-expr-exn (i "return (1 + 1) || 1;") "1 + 1"))
 
 (test-case
  "chained || and &&"
- (check-type-error (i "return 1 || 1/0 || 1/0;")
-                   type:bool
-                   1)
- (check-type-error (i "return 1 && 1/0 && 1/0;")
-                   type:bool
-                   1))
+ (check-bool-expr-exn (i "return 1 || 1/0 || 1/0;") "1")
+ (check-bool-expr-exn (i "return 1 && 1/0 && 1/0;") "1"))

--- a/test/interpret/op-error-tests.rkt
+++ b/test/interpret/op-error-tests.rkt
@@ -85,6 +85,12 @@
                    (list (list type:int type:int))
                    '(#F 0)))
 
+(test-case
+ "divide by zero"
+ (check-exn-result (i "return 1 / 0;")
+                   ue:type:divide-by-zero
+                   '(return)))
+
 ; ; NUM COMPARISON
 
 (test-case

--- a/test/interpret/op-error-tests.rkt
+++ b/test/interpret/op-error-tests.rkt
@@ -13,12 +13,14 @@
   (check-equal? (ue:exn:type (car exn-result)) ue:type:expected-boolean-expr)
   (check-equal? (ue:exn:property 'expr (car exn-result)) expr-string))
 
-(define-check (check-type-error exn-result expected-type expected-val)
+(define-check (check-type-error exn-result op expected-type expected-val)
   (define exn (car exn-result))
   (check-equal? (ue:exn:type exn) ue:type:type-mismatch)
-  (check-equal? (ue:exn:property 'expected-type exn)
+  (check-equal? (ue:exn:property 'op-symbol exn)
+                op)
+  (check-equal? (ue:exn:property 'expected-types exn)
                 expected-type)
-  (check-equal? (ue:exn:property 'val exn)
+  (check-equal? (ue:exn:property 'vals exn)
                 expected-val))
 
 ; ; SHORT-CIRCUIT ||, &&
@@ -57,3 +59,42 @@
  "chained || and &&"
  (check-bool-expr-exn (i "return 1 || 1/0 || 1/0;") "1")
  (check-bool-expr-exn (i "return 1 && 1/0 && 1/0;") "1"))
+
+; ; ARITHMETIC OPERATORS
+
+(test-case
+ "bool in +-*/%"
+ (check-type-error (i "return true + 2;")
+                   '+
+                   (list (list type:int type:int))
+                   '(#T 2))
+ (check-type-error (i "return -false;")
+                   '-
+                   (list (list type:int) (list type:int type:int))
+                   '(#F))
+ (check-type-error (i "return 5 * (1 == 2);")
+                   '*
+                   (list (list type:int type:int))
+                   '(5 #F))
+ (check-type-error (i "return true / (1 == 2);")
+                   '/
+                   (list (list type:int type:int))
+                   '(#t #f))
+ (check-type-error (i "function foo() { return false; } return foo() % 0;")
+                   '%
+                   (list (list type:int type:int))
+                   '(#F 0)))
+
+; ; NUM COMPARISON
+
+(test-case
+ "bool in < where bool expected"
+ (check-type-error (i "if (5 < (1 == 2)) return 6;")
+                   '<
+                   (list (list type:int type:int))
+                   '(5 #F))
+ (check-type-error (i "return ((1 == 2) >= 5) && false;")
+                   '>=
+                   (list (list type:int type:int))
+                   '(#F 5)))
+

--- a/test/interpret/v1-error-tests.rkt
+++ b/test/interpret/v1-error-tests.rkt
@@ -275,7 +275,7 @@ finally {
 (test-case
  "int in if cond"
  (check-exn-result (i "if (1) return 0;")
-                   ue:type:type-mismatch
+                   ue:type:expected-boolean-expr
                    '(if))
  (check-exn-result (i "if (1 + 1) return 0;")
                    ue:type:expected-boolean-expr
@@ -284,7 +284,7 @@ finally {
 (test-case
  "int in while cond"
  (check-exn-result (i "while (1) return 0;")
-                   ue:type:type-mismatch
+                   ue:type:expected-boolean-expr
                    '(while))
  (check-exn-result (i "while (1 + 1) return 0;")
                    ue:type:expected-boolean-expr

--- a/test/interpret/v1-error-tests.rkt
+++ b/test/interpret/v1-error-tests.rkt
@@ -275,7 +275,7 @@ finally {
 (test-case
  "int in if cond"
  (check-exn-result (i "if (1) return 0;")
-                   ue:type:expected-boolean-val
+                   ue:type:type-mismatch
                    '(if))
  (check-exn-result (i "if (1 + 1) return 0;")
                    ue:type:expected-boolean-expr
@@ -284,7 +284,7 @@ finally {
 (test-case
  "int in while cond"
  (check-exn-result (i "while (1) return 0;")
-                   ue:type:expected-boolean-val
+                   ue:type:type-mismatch
                    '(while))
  (check-exn-result (i "while (1 + 1) return 0;")
                    ue:type:expected-boolean-expr

--- a/test/interpret/v2-error-tests.rkt
+++ b/test/interpret/v2-error-tests.rkt
@@ -394,25 +394,25 @@ function main() { functor(); }")])
 (test-case
  "Int returning function in || / &&"
  (check-exn-result (i "function foo() { return 1; }  function main() { return foo() || true; }")
-                   ue:type:expected-boolean-val
+                   ue:type:type-mismatch
                    '(return "main()"))
  (check-exn-result (i "function foo() { return 1; }  function main() { return  true && foo(); }")
-                   ue:type:expected-boolean-val
+                   ue:type:type-mismatch
                    '(return "main()")))
 
 (test-case
  "Int returning function in if/while cond"
  (check-exn-result (i "function foo() { return 1; }  function main() { if (foo()) return 0; }")
-                   ue:type:expected-boolean-val
+                   ue:type:type-mismatch
                    '(if "main()"))
  (check-exn-result (i "function foo() { return 1; }  function main() { while (foo()) return 0; }")
-                   ue:type:expected-boolean-val
+                   ue:type:type-mismatch
                    '(while "main()")))
 
 (test-case
  "Int returning function in || / && in fun arg"
  (check-exn-result (i "function foo(b) { return b; }  function main() { return foo(1 || 2); }")
-                   ue:type:expected-boolean-val
+                   ue:type:type-mismatch
                    '(return "main()"))
  (check-exn-result (i "function foo(b) { return b; }  function main() { return foo((1 + 1) && 2); }")
                    ue:type:expected-boolean-expr
@@ -421,10 +421,10 @@ function main() { functor(); }")])
 (test-case
  "int val/ref param used in if/while cond"
  (check-exn-result (i "function foo(b) { if (b) return 0; }  function main() { return foo(1); }")
-                   ue:type:expected-boolean-val
+                   ue:type:type-mismatch
                    '(if "foo(b)" return "main()"))
  (check-exn-result (i "function foo(&b) { while (b) return 0; }  function main() { var a = 1; return foo(a); }")
-                   ue:type:expected-boolean-val
+                   ue:type:type-mismatch
                    '(while "foo(&b)" return "main()")))
  
  

--- a/test/interpret/v2-error-tests.rkt
+++ b/test/interpret/v2-error-tests.rkt
@@ -394,25 +394,25 @@ function main() { functor(); }")])
 (test-case
  "Int returning function in || / &&"
  (check-exn-result (i "function foo() { return 1; }  function main() { return foo() || true; }")
-                   ue:type:type-mismatch
+                   ue:type:expected-boolean-expr
                    '(return "main()"))
  (check-exn-result (i "function foo() { return 1; }  function main() { return  true && foo(); }")
-                   ue:type:type-mismatch
+                   ue:type:expected-boolean-expr
                    '(return "main()")))
 
 (test-case
  "Int returning function in if/while cond"
  (check-exn-result (i "function foo() { return 1; }  function main() { if (foo()) return 0; }")
-                   ue:type:type-mismatch
+                   ue:type:expected-boolean-expr
                    '(if "main()"))
  (check-exn-result (i "function foo() { return 1; }  function main() { while (foo()) return 0; }")
-                   ue:type:type-mismatch
+                   ue:type:expected-boolean-expr
                    '(while "main()")))
 
 (test-case
  "Int returning function in || / && in fun arg"
  (check-exn-result (i "function foo(b) { return b; }  function main() { return foo(1 || 2); }")
-                   ue:type:type-mismatch
+                   ue:type:expected-boolean-expr
                    '(return "main()"))
  (check-exn-result (i "function foo(b) { return b; }  function main() { return foo((1 + 1) && 2); }")
                    ue:type:expected-boolean-expr
@@ -421,10 +421,10 @@ function main() { functor(); }")])
 (test-case
  "int val/ref param used in if/while cond"
  (check-exn-result (i "function foo(b) { if (b) return 0; }  function main() { return foo(1); }")
-                   ue:type:type-mismatch
+                   ue:type:expected-boolean-expr
                    '(if "foo(b)" return "main()"))
  (check-exn-result (i "function foo(&b) { while (b) return 0; }  function main() { var a = 1; return foo(a); }")
-                   ue:type:type-mismatch
+                   ue:type:expected-boolean-expr
                    '(while "foo(&b)" return "main()")))
  
  

--- a/test/interpret/v3-error-tests.rkt
+++ b/test/interpret/v3-error-tests.rkt
@@ -84,7 +84,7 @@ class A {
 (test-case
  "instance in if/while cond"
  (check-exn-result (i "class A { static function main() { var a = new A(); if (a) return 0; } }" "A")
-                   ue:type:type-mismatch
+                   ue:type:expected-boolean-expr
                    '(if "A::main()"))
  (check-exn-result (i "class A { static function main() { if (new A()) return 0; } }" "A")
                    ue:type:expected-boolean-expr
@@ -93,7 +93,7 @@ class A {
 (test-case
  "instance in || / &&"
  (check-exn-result (i "class A { static function main() { var a = new A(); return a || true; } }" "A")
-                   ue:type:type-mismatch
+                   ue:type:expected-boolean-expr
                    '(return "A::main()"))
  (check-exn-result (i "class A { static function main() { return new B() || false; } }" "A")
                    ue:type:expected-boolean-expr

--- a/test/interpret/v3-error-tests.rkt
+++ b/test/interpret/v3-error-tests.rkt
@@ -84,7 +84,7 @@ class A {
 (test-case
  "instance in if/while cond"
  (check-exn-result (i "class A { static function main() { var a = new A(); if (a) return 0; } }" "A")
-                   ue:type:expected-boolean-val
+                   ue:type:type-mismatch
                    '(if "A::main()"))
  (check-exn-result (i "class A { static function main() { if (new A()) return 0; } }" "A")
                    ue:type:expected-boolean-expr
@@ -93,7 +93,7 @@ class A {
 (test-case
  "instance in || / &&"
  (check-exn-result (i "class A { static function main() { var a = new A(); return a || true; } }" "A")
-                   ue:type:expected-boolean-val
+                   ue:type:type-mismatch
                    '(return "A::main()"))
  (check-exn-result (i "class A { static function main() { return new B() || false; } }" "A")
                    ue:type:expected-boolean-expr

--- a/test/parse/parser-tests.rkt
+++ b/test/parse/parser-tests.rkt
@@ -27,7 +27,7 @@ return x;
     (begin
       (try
        ((= x (+ x 10)) (break))
-       (catch (e) ((if (|| true false) (return 0))))
+       (catch (e) ((if (\|\| true false) (return 0))))
        (finally ((= x (+ x 1)))))))
    (return x)))
 


### PR DESCRIPTION
adds user-exns for type errors w/ operators and for divide-by-zero.  
also fixes how the || operator is displayed in some circumstances
merge `expected-boolean-val` and `expected-boolean-expr` to just the latter.
closes #53 
progress on #54 